### PR TITLE
BlockBreakEvent

### DIFF
--- a/prison-core/src/main/java/tech/mcprison/prison/events/BlockBreakEvent.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/events/BlockBreakEvent.java
@@ -1,0 +1,42 @@
+package tech.mcprison.prison.events;
+
+import tech.mcprison.prison.internal.Player;
+import tech.mcprison.prison.util.BlockType;
+import tech.mcprison.prison.util.Location;
+
+/**
+ * Created by DMP9 on 23/01/2017.
+ */
+public class BlockBreakEvent implements Cancelable {
+
+    private BlockType block;
+    private Location blockLocation;
+    private Player player;
+    private boolean canceled = false;
+
+    public BlockBreakEvent(BlockType block, Location blockLocation, Player player) {
+        this.block = block;
+        this.blockLocation = blockLocation;
+        this.player = player;
+    }
+
+    @Override public boolean isCanceled() {
+        return canceled;
+    }
+
+    @Override public void setCanceled(boolean canceled) {
+        this.canceled = canceled;
+    }
+
+    public BlockType getBlock() {
+        return block;
+    }
+
+    public Location getBlockLocation() {
+        return blockLocation;
+    }
+
+    public Player getPlayer() {
+        return player;
+    }
+}

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/SpigotListener.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/SpigotListener.java
@@ -22,6 +22,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
+import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
@@ -68,6 +69,17 @@ public class SpigotListener implements Listener {
         org.bukkit.Location block = e.getBlockPlaced().getLocation();
         tech.mcprison.prison.events.BlockPlaceEvent event =
             new tech.mcprison.prison.events.BlockPlaceEvent(
+                BlockType.getBlock(e.getBlock().getTypeId()),
+                new Location(new SpigotWorld(block.getWorld()), block.getX(), block.getY(),
+                    block.getZ()), (new SpigotPlayer(e.getPlayer())));
+        Prison.get().getEventBus().post(event);
+        e.setCancelled(event.isCanceled());
+    }
+
+    @EventHandler public void onBlockBreak(BlockBreakEvent e){
+        org.bukkit.Location block = e.getBlock().getLocation();
+        tech.mcprison.prison.events.BlockBreakEvent event =
+            new tech.mcprison.prison.events.BlockBreakEvent(
                 BlockType.getBlock(e.getBlock().getTypeId()),
                 new Location(new SpigotWorld(block.getWorld()), block.getX(), block.getY(),
                     block.getZ()), (new SpigotPlayer(e.getPlayer())));


### PR DESCRIPTION
This PR adds capability for BlockBreakEvents (ignore the mistake in the commit name). This is required in the mines module for the final checkbox.